### PR TITLE
Check for test.js as well as tests.js

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -39,9 +39,11 @@ const getFolderTests = (baseFolder, folderName, prefix = '') => {
     missingTests: []
   };
   const testsFile = path.join(folderName, 'tests.js');
+  const testFile = path.join(folderName, 'test.js');
   const modulesFile = path.join(folderName, 'modules.js');
-  if (fileExists(testsFile)) {
+  if (fileExists(testsFile) || fileExists(testFile)) {
     let tmpTests = require(testsFile);
+    tmpTests = tmpTests.concat(testFile);
     tmpTests.forEach((test) => {
       test.fullName = test.name;
       if (prefix !== '') {


### PR DESCRIPTION
Right now are only checking for 'tests.js' 
This is confusing
so we are considering both (concatting them)

also the readme.md is saying test.js instead of tests.js